### PR TITLE
Fix creation of mutliple sub QWindows

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1378,6 +1378,7 @@ bool OBSApp::OBSInit()
 	ProfileScope("OBSApp::OBSInit");
 
 	setAttribute(Qt::AA_UseHighDpiPixmaps);
+	setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
 	qRegisterMetaType<VoidFunc>();
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -202,8 +202,6 @@ OBSBasic::OBSBasic(QWidget *parent)
 	qRegisterMetaTypeStreamOperators<SignalContainer<OBSScene>>(
 		"SignalContainer<OBSScene>");
 
-	setAttribute(Qt::WA_NativeWindow);
-
 #if TWITCH_ENABLED
 	RegisterTwitchAuth();
 #endif


### PR DESCRIPTION
Tested on X11 and Wayland.

    Native windows really only make sense for previews. They can be a new
    xcb_window or a wayland subsurface.
    
    For historical reasons setting a widget to native will also affect
    ancestors. Qt will still draw them as part of the parent as they are
    never mapped, but a window is nonetheless created.
    
    This is especially problematic on wayland as then the subsurface is
    parented to an unmapped window.
    
    This default behaviour can be turned off. Now only the native widgets
    (the video previews) are actually native.
