### PR TITLE
CI: use flatpak-builder sub-action

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -35,7 +35,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Build Flatpak Manifest
-      uses: bilelmoussaoui/flatpak-github-actions@master
+      uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
       if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
       with:
         bundle: obs-studio-${{ github.sha }}.flatpak


### PR DESCRIPTION
The flatpak-github-actions nowadays contains two actions:
- flatpak-builder: for building and uploading a bundle 
- flat-manager: for deploying the bundle to a remote repository
this change makes sure we are using the right action

needs to be merged from the action side first :) 